### PR TITLE
feat: allow use custom OpenAI base URL

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,12 @@ import {
 	DEFAULT_IMAGE_MODEL,
 	DEFAULT_OAI_IMAGE_MODEL,
 	DEFAULT_MAX_TOKENS,
+	OPENAI_BASE_URL,
 } from "./settings";
 
 interface AiAssistantSettings {
 	mySetting: string;
+	openAIBaseUrl: string;
 	openAIapiKey: string;
 	anthropicApiKey: string;
 	modelName: string;
@@ -31,6 +33,7 @@ interface AiAssistantSettings {
 const DEFAULT_SETTINGS: AiAssistantSettings = {
 	mySetting: "default",
 	openAIapiKey: "",
+	openAIBaseUrl: OPENAI_BASE_URL,
 	anthropicApiKey: "",
 	modelName: DEFAULT_OAI_IMAGE_MODEL,
 	imageModelName: DEFAULT_IMAGE_MODEL,
@@ -57,6 +60,7 @@ export default class AiAssistantPlugin extends Plugin {
 				this.settings.openAIapiKey,
 				this.settings.modelName,
 				this.settings.maxTokens,
+				this.settings.openAIBaseUrl,
 			);
 		}
 	}
@@ -176,6 +180,17 @@ class AiAssistantSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 		containerEl.createEl("h2", { text: "Settings for my AI assistant." });
+
+		new Setting(containerEl).setName("OpenAI Base URL").addText((text) =>
+			text
+				.setPlaceholder("Enter OpenAI base URL key here")
+				.setValue(this.plugin.settings.openAIBaseUrl)
+				.onChange(async (value) => {
+					this.plugin.settings.openAIBaseUrl = value;
+					await this.plugin.saveSettings();
+					this.plugin.build_api();
+				}),
+		);
 
 		new Setting(containerEl).setName("OpenAI API Key").addText((text) =>
 			text

--- a/src/openai_api.ts
+++ b/src/openai_api.ts
@@ -10,8 +10,9 @@ export class OpenAIAssistant {
 	maxTokens: number;
 	apiKey: string;
 
-	constructor(apiKey: string, modelName: string, maxTokens: number) {
+	constructor(apiKey: string, modelName: string, maxTokens: number, openAIBaseUrl: string = 'http://localhost:1234/v1') {
 		this.apiFun = new OpenAI({
+			baseURL: openAIBaseUrl,
 			apiKey: apiKey,
 			dangerouslyAllowBrowser: true,
 		});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,9 @@ export const OAI_IMAGE_CAPABLE_MODELS = [
 export const DEFAULT_OAI_IMAGE_MODEL = "gpt-4o-mini";
 
 export const ALL_MODELS = {
+	"qwen2.5-coder-7b-instruct": "qwen2.5-coder-7b-instruct",
+	"mistral-vlm-7b": "mistral-vlm-7b",
+	"gemini-2.0-flash-exp": "gemini-2.0-flash-exp",
 	"gpt-4o-mini": "gpt-4o mini",
 	"o1-mini": "o1-mini",
 	"o1-preview": "o1-preview",
@@ -29,3 +32,5 @@ export const ALL_IMAGE_MODELS = {
 export const DEFAULT_IMAGE_MODEL = "dall-e-3";
 
 export const DEFAULT_MAX_TOKENS = 500;
+
+export const OPENAI_BASE_URL = "https://api.openai.com/v1";


### PR DESCRIPTION
Allow use OpenAI compatible API, for example, LM Studio: `http://localhost:1234/v1` 