### PR TITLE
feat: add support for custom OpenAI-compatible inference endpoints

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ interface AiAssistantSettings {
 	imgFolder: string;
 	language: string;
 	customEndpoint: string;
+	useResponsesApi: boolean;
 }
 
 const DEFAULT_SETTINGS: AiAssistantSettings = {
@@ -42,6 +43,7 @@ const DEFAULT_SETTINGS: AiAssistantSettings = {
 	imgFolder: "AiAssistant/Assets",
 	language: "",
 	customEndpoint: "",
+	useResponsesApi: false,
 };
 
 export default class AiAssistantPlugin extends Plugin {
@@ -65,6 +67,7 @@ export default class AiAssistantPlugin extends Plugin {
 				effectiveModel,
 				this.settings.maxTokens,
 				customEndpoint,
+				this.settings.useResponsesApi,
 			);
 		}
 	}
@@ -185,27 +188,36 @@ class AiAssistantSettingTab extends PluginSettingTab {
 		containerEl.empty();
 		containerEl.createEl("h2", { text: "Settings for my AI assistant." });
 
-		new Setting(containerEl).setName("OpenAI API Key").addText((text) =>
-			text
-				.setPlaceholder("Enter OpenAI key here")
-				.setValue(this.plugin.settings.openAIapiKey)
-				.onChange(async (value) => {
-					this.plugin.settings.openAIapiKey = value;
-					await this.plugin.saveSettings();
-					this.plugin.build_api();
-				}),
-		);
+		new Setting(containerEl)
+			.setName("OpenAI / Custom Endpoint API Key")
+			.setDesc(
+				"API key for OpenAI or any custom inference endpoint. " +
+				"When using a custom endpoint (e.g. NVIDIA), enter that provider's API key here.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("Enter API key here")
+					.setValue(this.plugin.settings.openAIapiKey)
+					.onChange(async (value) => {
+						this.plugin.settings.openAIapiKey = value;
+						await this.plugin.saveSettings();
+						this.plugin.build_api();
+					}),
+			);
 
-		new Setting(containerEl).setName("Anthropic API Key").addText((text) =>
-			text
-				.setPlaceholder("Enter Anthropic key here")
-				.setValue(this.plugin.settings.anthropicApiKey)
-				.onChange(async (value) => {
-					this.plugin.settings.anthropicApiKey = value;
-					await this.plugin.saveSettings();
-					this.plugin.build_api();
-				}),
-		);
+		new Setting(containerEl)
+			.setName("Anthropic API Key")
+			.setDesc("API key for Anthropic (used only when no custom endpoint is set and a Claude model is selected).")
+			.addText((text) =>
+				text
+					.setPlaceholder("Enter Anthropic key here")
+					.setValue(this.plugin.settings.anthropicApiKey)
+					.onChange(async (value) => {
+						this.plugin.settings.anthropicApiKey = value;
+						await this.plugin.saveSettings();
+						this.plugin.build_api();
+					}),
+			);
 		containerEl.createEl("h3", { text: "Custom Inference Endpoint" });
 
 		new Setting(containerEl)
@@ -241,6 +253,22 @@ class AiAssistantSettingTab extends PluginSettingTab {
 						this.plugin.build_api();
 					}),
 			);
+
+		new Setting(containerEl)
+			.setName("Use Responses API")
+			.setDesc(
+				"Use the /v1/responses endpoint instead of /v1/chat/completions. " +
+				"Required for some providers (e.g. NVIDIA inference-api.nvidia.com with GPT models).",
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.useResponsesApi)
+					.onChange(async (value) => {
+						this.plugin.settings.useResponsesApi = value;
+						await this.plugin.saveSettings();
+						this.plugin.build_api();
+					});
+			});
 
 		containerEl.createEl("h3", { text: "Text Assistant" });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,11 +21,13 @@ interface AiAssistantSettings {
 	openAIapiKey: string;
 	anthropicApiKey: string;
 	modelName: string;
+	customModelName: string;
 	imageModelName: string;
 	maxTokens: number;
 	replaceSelection: boolean;
 	imgFolder: string;
 	language: string;
+	customEndpoint: string;
 }
 
 const DEFAULT_SETTINGS: AiAssistantSettings = {
@@ -33,11 +35,13 @@ const DEFAULT_SETTINGS: AiAssistantSettings = {
 	openAIapiKey: "",
 	anthropicApiKey: "",
 	modelName: DEFAULT_OAI_IMAGE_MODEL,
+	customModelName: "",
 	imageModelName: DEFAULT_IMAGE_MODEL,
 	maxTokens: DEFAULT_MAX_TOKENS,
 	replaceSelection: true,
 	imgFolder: "AiAssistant/Assets",
 	language: "",
+	customEndpoint: "",
 };
 
 export default class AiAssistantPlugin extends Plugin {
@@ -45,18 +49,22 @@ export default class AiAssistantPlugin extends Plugin {
 	aiAssistant: OpenAIAssistant;
 
 	build_api() {
-		if (this.settings.modelName.includes("claude")) {
+		const effectiveModel = this.settings.customModelName.trim() || this.settings.modelName;
+		const customEndpoint = this.settings.customEndpoint.trim() || undefined;
+
+		if (effectiveModel.includes("claude") && !customEndpoint) {
 			this.aiAssistant = new AnthropicAssistant(
 				this.settings.openAIapiKey,
 				this.settings.anthropicApiKey,
-				this.settings.modelName,
+				effectiveModel,
 				this.settings.maxTokens,
 			);
 		} else {
 			this.aiAssistant = new OpenAIAssistant(
 				this.settings.openAIapiKey,
-				this.settings.modelName,
+				effectiveModel,
 				this.settings.maxTokens,
+				customEndpoint,
 			);
 		}
 	}
@@ -198,6 +206,42 @@ class AiAssistantSettingTab extends PluginSettingTab {
 					this.plugin.build_api();
 				}),
 		);
+		containerEl.createEl("h3", { text: "Custom Inference Endpoint" });
+
+		new Setting(containerEl)
+			.setName("Custom API Base URL")
+			.setDesc(
+				"Optional. Use an OpenAI-compatible endpoint (e.g. https://integrate.api.nvidia.com/v1). " +
+				"When set, all text requests are routed through this endpoint using the OpenAI SDK.",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("https://integrate.api.nvidia.com/v1")
+					.setValue(this.plugin.settings.customEndpoint)
+					.onChange(async (value) => {
+						this.plugin.settings.customEndpoint = value;
+						await this.plugin.saveSettings();
+						this.plugin.build_api();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Custom Model Name")
+			.setDesc(
+				"Optional. Override the model dropdown with a custom model identifier " +
+				"(e.g. nvidia/llama-3.1-nemotron-70b-instruct).",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("nvidia/llama-3.1-nemotron-70b-instruct")
+					.setValue(this.plugin.settings.customModelName)
+					.onChange(async (value) => {
+						this.plugin.settings.customModelName = value;
+						await this.plugin.saveSettings();
+						this.plugin.build_api();
+					}),
+			);
+
 		containerEl.createEl("h3", { text: "Text Assistant" });
 
 		new Setting(containerEl)

--- a/src/openai_api.ts
+++ b/src/openai_api.ts
@@ -9,8 +9,9 @@ export class OpenAIAssistant {
 	apiFun: any;
 	maxTokens: number;
 	apiKey: string;
+	useResponsesApi: boolean;
 
-	constructor(apiKey: string, modelName: string, maxTokens: number, baseURL?: string) {
+	constructor(apiKey: string, modelName: string, maxTokens: number, baseURL?: string, useResponsesApi?: boolean) {
 		const config: { apiKey: string; dangerouslyAllowBrowser: boolean; baseURL?: string } = {
 			apiKey: apiKey,
 			dangerouslyAllowBrowser: true,
@@ -22,6 +23,7 @@ export class OpenAIAssistant {
 		this.modelName = modelName;
 		this.maxTokens = maxTokens;
 		this.apiKey = apiKey;
+		this.useResponsesApi = useResponsesApi || false;
 	}
 
 	display_error = (err: any) => {
@@ -36,6 +38,16 @@ export class OpenAIAssistant {
 		prompt_list: { [key: string]: string }[],
 		htmlEl?: HTMLElement,
 		view?: MarkdownView,
+	) => {
+		if (this.useResponsesApi) {
+			return this.responses_api_call(prompt_list, htmlEl);
+		}
+		return this.completions_api_call(prompt_list, htmlEl);
+	};
+
+	private completions_api_call = async (
+		prompt_list: { [key: string]: string }[],
+		htmlEl?: HTMLElement,
 	) => {
 		const streamMode = htmlEl !== undefined;
 		const has_img = prompt_list.some((el) => Array.isArray(el.content));
@@ -69,6 +81,41 @@ export class OpenAIAssistant {
 				return htmlEl.innerHTML;
 			} else {
 				return response.choices[0].message.content;
+			}
+		} catch (err) {
+			this.display_error(err);
+		}
+	};
+
+	private responses_api_call = async (
+		prompt_list: { [key: string]: string }[],
+		htmlEl?: HTMLElement,
+	) => {
+		const streamMode = htmlEl !== undefined;
+		try {
+			if (streamMode) {
+				const stream = await this.apiFun.responses.create({
+					model: this.modelName,
+					input: prompt_list,
+					max_output_tokens: this.maxTokens,
+					stream: true,
+				});
+
+				let responseText = "";
+				for await (const event of stream) {
+					if (event.type === "response.output_text.delta") {
+						responseText = responseText.concat(event.delta);
+						htmlEl.innerHTML = responseText;
+					}
+				}
+				return htmlEl.innerHTML;
+			} else {
+				const response = await this.apiFun.responses.create({
+					model: this.modelName,
+					input: prompt_list,
+					max_output_tokens: this.maxTokens,
+				});
+				return response.output_text;
 			}
 		} catch (err) {
 			this.display_error(err);

--- a/src/openai_api.ts
+++ b/src/openai_api.ts
@@ -10,11 +10,15 @@ export class OpenAIAssistant {
 	maxTokens: number;
 	apiKey: string;
 
-	constructor(apiKey: string, modelName: string, maxTokens: number) {
-		this.apiFun = new OpenAI({
+	constructor(apiKey: string, modelName: string, maxTokens: number, baseURL?: string) {
+		const config: { apiKey: string; dangerouslyAllowBrowser: boolean; baseURL?: string } = {
 			apiKey: apiKey,
 			dangerouslyAllowBrowser: true,
-		});
+		};
+		if (baseURL) {
+			config.baseURL = baseURL;
+		}
+		this.apiFun = new OpenAI(config);
 		this.modelName = modelName;
 		this.maxTokens = maxTokens;
 		this.apiKey = apiKey;
@@ -132,16 +136,19 @@ export class OpenAIAssistant {
 
 export class AnthropicAssistant extends OpenAIAssistant {
 	anthropicApiKey: string;
+	anthropicBaseURL: string;
 
 	constructor(
 		openAIapiKey: string,
 		anthropicApiKey: string,
 		modelName: string,
 		maxTokens: number,
+		baseURL?: string,
 	) {
 		super(openAIapiKey, modelName, maxTokens);
 
 		this.anthropicApiKey = anthropicApiKey;
+		this.anthropicBaseURL = baseURL || "https://api.anthropic.com/v1/messages";
 	}
 
 	text_api_call = async (
@@ -151,7 +158,7 @@ export class AnthropicAssistant extends OpenAIAssistant {
 	) => {
 		try {
 			const response = await request({
-				url: "https://api.anthropic.com/v1/messages",
+				url: this.anthropicBaseURL,
 
 				method: "POST",
 


### PR DESCRIPTION
## Summary

- Adds two new optional settings: **Custom API Base URL** and **Custom Model Name**
- When a custom endpoint is configured, all text inference requests are routed through it via the OpenAI SDK's `baseURL` parameter, enabling any OpenAI-compatible provider (e.g. NVIDIA `build.nvidia.com` / `integrate.api.nvidia.com`, local servers like ollama, Azure OpenAI, etc.)
- The custom model name field allows specifying provider-specific model identifiers (e.g. `nvidia/llama-3.1-nemotron-70b-instruct`) that aren't in the built-in dropdown

## Changes

### `src/main.ts`
- Added `customEndpoint` and `customModelName` fields to `AiAssistantSettings` interface and defaults
- Updated `build_api()` to resolve the effective model name (custom overrides dropdown) and pass the custom endpoint to the OpenAI SDK
- When a custom endpoint is set, requests always use `OpenAIAssistant` (since custom endpoints are OpenAI-compatible)
- Added a **Custom Inference Endpoint** settings section with text fields for base URL and model name

### `src/openai_api.ts`
- `OpenAIAssistant` constructor now accepts an optional `baseURL` parameter, passed to the OpenAI SDK when set
- `AnthropicAssistant` constructor now accepts an optional `baseURL` parameter, replacing the hardcoded Anthropic URL when set

## Backward Compatibility

- Both new settings default to empty strings, so existing users experience no change
- The built-in model dropdown and provider detection continue to work as before when custom fields are empty

## Test Plan

- [ ] Verify default behavior (no custom endpoint) works unchanged for OpenAI and Anthropic models
- [ ] Set a custom endpoint (e.g. `https://integrate.api.nvidia.com/v1`) with a valid API key and custom model name, and verify text chat works
- [ ] Verify clearing the custom fields reverts to default behavior
- [ ] Verify settings persist across plugin reload


Made with [Cursor](https://cursor.com)